### PR TITLE
ui: uPlot sticked legend 

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -136,6 +136,7 @@
     "topojson": "^3.0.2",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",
+    "uplot": "^1.6.8",
     "url-loader": "2.1.0",
     "us-atlas": "^1.0.2",
     "webpack": "^4.41.5",

--- a/pkg/ui/src/util/convert.ts
+++ b/pkg/ui/src/util/convert.ts
@@ -19,6 +19,17 @@ export function NanoToMilli(nano: number): number {
   return nano / 1.0e6;
 }
 
+export function MilliToSeconds(milli: number): number {
+  return milli / 1.0e3;
+}
+
+/**
+ * NanoToSeconds converts a nanoseconds value into seconds.
+ */
+export function NanoToSeconds(nano: number): number {
+  return nano / 1.0e9;
+}
+
 /**
  * MilliToNano converts a millisecond value into nanoseconds.
  */

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -15,24 +15,33 @@ import * as nvd3 from "nvd3";
 import { createSelector } from "reselect";
 
 import * as protos from "src/js/protos";
-import { HoverState, hoverOn, hoverOff } from "src/redux/hover";
+import { cockroach } from "src/js/protos";
+import { hoverOff, hoverOn, HoverState } from "src/redux/hover";
 import { findChildrenOfType } from "src/util/find";
 import {
-  ConfigureLineChart,
-  InitLineChart,
+  AxisDomain,
+  calculateXAxisDomain,
+  calculateYAxisDomain,
   CHART_MARGINS,
+  ConfigureLineChart,
   ConfigureLinkedGuideline,
+  configureUPlotLineChart,
+  InitLineChart,
 } from "src/views/cluster/util/graphs";
 import {
-  Metric,
-  MetricProps,
   Axis,
   AxisProps,
+  Metric,
+  MetricProps,
+  MetricsDataComponentProps,
   QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
-import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
 import Visualization from "src/views/cluster/components/visualization";
 import { NanoToMilli } from "src/util/convert";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+import { findClosestTimeScale } from "oss/src/redux/timewindow";
+import TimeSeriesQueryResponse = cockroach.ts.tspb.TimeSeriesQueryResponse;
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -47,7 +56,7 @@ interface LineGraphProps extends MetricsDataComponentProps {
   hoverState?: HoverState;
 }
 
-interface LineGraphState {
+interface LineGraphStateOld {
   lastData?: TSResponse;
   lastTimeInfo?: QueryTimeInfo;
 }
@@ -57,7 +66,10 @@ interface LineGraphState {
  * supports a single Y-axis, but multiple metrics can be graphed on the same
  * axis.
  */
-export class LineGraph extends React.Component<LineGraphProps, LineGraphState> {
+export class LineGraphOld extends React.Component<
+  LineGraphProps,
+  LineGraphStateOld
+> {
   // The SVG Element reference in the DOM used to render the graph.
   graphEl: React.RefObject<SVGSVGElement> = React.createRef();
 
@@ -286,6 +298,226 @@ export class LineGraph extends React.Component<LineGraphProps, LineGraphState> {
             ref={this.graphEl}
             {...hoverProps}
           />
+        </div>
+      </Visualization>
+    );
+  }
+}
+
+// touPlot formats our timeseries data into the format
+// uPlot expects which is a 2-dimensional array where the
+// first array contains the x-values (time).
+function touPlot(data: TimeSeriesQueryResponse): any {
+  // Here's an example of what this code is attempting to control for.
+  // We produce `result` series that contain their own x-values. uPlot
+  // expects *one* x-series that all y-values match up to. So first we
+  // need to take the union of all timestamps across all series, and then
+  // produce y-values that match up to those. Any missing values will
+  // be set to null and uPlot expects that.
+  //
+  // our data: [
+  //   [(11:00, 1),             (11:05, 2),  (11:06, 3), (11:10, 4),           ],
+  //   [(11:00, 1), (11:03, 20),             (11:06, 7),            (11:11, 40)],
+  // ]
+  //
+  // for uPlot: [
+  //   [11:00, 11:03, 11:05, 11:06, 11:10, 11:11]
+  //   [1, null, 2, 3, 4, null],
+  //   [1, 20, null, 7, null, 40],
+  // ]
+  if (!data || !data.results) {
+    return [];
+  }
+
+  const xValuesComplete: number[] = [
+    ...new Set(
+      data.results.flatMap((result) =>
+        result.datapoints.map((d) => d.timestamp_nanos.toNumber()),
+      ),
+    ),
+  ].sort((a, b) => a - b);
+
+  const yValuesComplete: (number | null)[][] = data.results.map((result) => {
+    return xValuesComplete.map((ts) => {
+      const found = result.datapoints.find(
+        (dp) => dp.timestamp_nanos.toNumber() === ts,
+      );
+      return found ? found.value : null;
+    });
+  });
+
+  return [xValuesComplete.map((ts) => NanoToMilli(ts)), ...yValuesComplete];
+}
+
+// LineGraph wraps the uPlot library into a React component
+// when the component is first initialized, we wait until
+// data is available and then construct the uPlot object
+// and store its ref in a global variable.
+// Once we receive updates to props, we push new data to the
+// uPlot object.
+export class LineGraph extends React.Component<LineGraphProps, {}> {
+  constructor(props) {
+    super(props);
+
+    this.setNewTimeRange = this.setNewTimeRange.bind(this);
+  }
+
+  // axis is copied from the nvd3 LineGraph component above
+  axis = createSelector(
+    (props: { children?: React.ReactNode }) => props.children,
+    (children) => {
+      const axes: React.ReactElement<AxisProps>[] = findChildrenOfType(
+        children as any,
+        Axis,
+      );
+      if (axes.length === 0) {
+        console.warn(
+          "LineGraph requires the specification of at least one axis.",
+        );
+        return null;
+      }
+      if (axes.length > 1) {
+        console.warn(
+          "LineGraph currently only supports a single axis; ignoring additional axes.",
+        );
+      }
+      return axes[0];
+    },
+  );
+
+  // metrics is copied from the nvd3 LineGraph component above
+  metrics = createSelector(
+    (props: { children?: React.ReactNode }) => props.children,
+    (children) => {
+      return findChildrenOfType(
+        children as any,
+        Metric,
+      ) as React.ReactElement<MetricProps>[];
+    },
+  );
+
+  // setNewTimeRange uses code from the TimeScaleDropdown component
+  // to set new start/end ranges in the query params and force a
+  // reload of the rest of the dashboard at new ranges via the props
+  // `setTimeRange` and `setTimeScale`.
+  // TODO(davidh): centralize management of query params for time range
+  // TODO(davidh): figure out why the timescale doesn't get more granular
+  // automatically when a narrower time frame is selected.
+  setNewTimeRange(startMillis: number, endMillis: number) {
+    const start = startMillis / 1e3;
+    const end = endMillis / 1e3;
+    this.props.setTimeRange({
+      start: moment.unix(start),
+      end: moment.unix(end),
+    });
+    const newTimeScale = findClosestTimeScale(end - start);
+    this.props.setTimeScale(newTimeScale);
+    const { pathname, search } = this.props.history.location;
+    const urlParams = new URLSearchParams(search);
+
+    urlParams.set("start", moment.unix(start).format("X"));
+    urlParams.set("end", moment.unix(end).format("X"));
+
+    this.props.history.push({
+      pathname,
+      search: urlParams.toString(),
+    });
+  }
+
+  u: uPlot;
+  el = React.createRef<HTMLDivElement>();
+
+  // yAxisDomain holds our computed AxisDomain object
+  // for the y Axis. The function to compute this was
+  // created to support the prior iteration
+  // of our line graphs. We recompute it manually
+  // when data changes, and uPlot options have access
+  // to a closure that holds a reference to this value.
+  yAxisDomain: AxisDomain;
+
+  // xAxisDomain holds our computed AxisDomain object
+  // for the x Axis. The function to compute this was
+  // created to support the prior iteration
+  // of our line graphs. We recompute it manually
+  // when data changes, and uPlot options have access
+  // to a closure that holds a reference to this value.
+  xAxisDomain: AxisDomain;
+
+  componentDidUpdate(prevProps: Readonly<LineGraphProps>) {
+    if (
+      // data was missing last time or we already have a `u`
+      // the latter could happen if we click away to a
+      // different dashboard and then back to one we had
+      // open previously.
+      (!prevProps.data || !this.u) &&
+      this.props.data &&
+      this.props.data.results
+    ) {
+      const data = this.props.data;
+      const metrics = this.metrics(this.props);
+      const axis = this.axis(this.props);
+      const uPlotData = touPlot(data);
+      this.yAxisDomain = calculateYAxisDomain(axis.props.units, data);
+      this.xAxisDomain = calculateXAxisDomain(this.props.timeInfo);
+
+      const options = configureUPlotLineChart(
+        metrics,
+        axis,
+        data,
+        this.setNewTimeRange,
+        () => this.xAxisDomain,
+        () => this.yAxisDomain,
+      );
+
+      this.u = new uPlot(options, uPlotData, this.el.current);
+    }
+    if (this.u && this.props.data && prevProps.data !== this.props.data) {
+      const axis = this.axis(this.props);
+      // The values of `this.yAxisDomain` and `this.xAxisDomain`
+      // are captured in arguments to `configureUPlotLineChart`
+      // and are called when recomputing certain axis and
+      // series options. This lets us use updated domains
+      // when redrawing the uPlot chart on data change.
+      this.yAxisDomain = calculateYAxisDomain(
+        axis.props.units,
+        this.props.data,
+      );
+      this.xAxisDomain = calculateXAxisDomain(this.props.timeInfo);
+
+      // The axis label option on uPlot doesn't accept
+      // a function that recomputes the label, so we need
+      // to manually update it in cases where we change
+      // the scale (this happens on byte/time-based Y
+      // axes where can change from MiB or KiB scales,
+      // for instance).
+      this.u.axes[1].label =
+        axis.props.label +
+        (this.yAxisDomain.label ? ` (${this.yAxisDomain.label})` : "");
+
+      const uPlotData = touPlot(this.props.data);
+      this.u.setData(uPlotData);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.u) {
+      this.u.destroy();
+      this.u = null;
+    }
+  }
+
+  render() {
+    const { title, subtitle, tooltip, data } = this.props;
+
+    return (
+      <Visualization
+        title={title}
+        subtitle={subtitle}
+        tooltip={tooltip}
+        loading={!data}
+      >
+        <div className="linegraph">
+          <div ref={this.el} />
         </div>
       </Visualization>
     );

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -91,22 +91,40 @@ $viz-sides = 62px
 
 .uplot
   display flex
+  > .u-legend
+    display none
+    position absolute
+    left 0
+    top 0
+    font-size 10px
+    background-color white
+    text-align left
+    margin-top 20px
+    z-index 100
+    pointer-events: none;
+    width: fit-content;
+    border-radius: 5px
+    padding: 10px;
+    border 1px solid rgba(0,0,0,0.1)
 
-.uplot > .u-legend
-  display none
-  position absolute
-  left 0
-  top 0
-  font-size 10px
-  background-color white
-  text-align left
-  margin-top 20px
-  z-index 100
-  pointer-events: none;
-  width: fit-content;
-  border-radius: 5px
-  padding: 10px;
-  border 1px solid rgba(0,0,0,0.1)
+  // stick the legend to the char's bottom.
+  // Chart height is hardcoded to 300px (pkg/ui/src/views/cluster/util/graphs.ts)
+  > .u-legend.u-legend--place-bottom
+    top 300px!important
+    left 0!important
+    width auto
+    margin-left -1px
+    margin-right -1px
+    border-top none
+    border-radius 0px 0px 5px 5px
+    padding-left 50px
 
-.u-legend .u-series
-  display block
+    // the first line in the legend represents Y-axis and it occupies an entire line
+    // to stand out from the rest of x-axis values
+    > tr:first-child
+      width 100%
+      font-size $font-size--small
+
+.u-legend:not(.u-legend--place-bottom)
+  .u-series
+    display block

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -26,7 +26,6 @@ $viz-sides = 62px
 
   &__content
     padding 0 10px 15px
-    height 200px
     &.visualization--loading
       display flex
       justify-content center
@@ -89,3 +88,25 @@ $viz-sides = 62px
 
 .linked-guideline__line
   stroke $link-color
+
+.uplot
+  display flex
+
+.uplot > .u-legend
+  display none
+  position absolute
+  left 0
+  top 0
+  font-size 10px
+  background-color white
+  text-align left
+  margin-top 20px
+  z-index 100
+  pointer-events: none;
+  width: fit-content;
+  border-radius: 5px
+  padding: 10px;
+  border 1px solid rgba(0,0,0,0.1)
+
+.u-legend .u-series
+  display block

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -58,6 +58,13 @@ import requestsDashboard from "./dashboards/requests";
 import hardwareDashboard from "./dashboards/hardware";
 import changefeedsDashboard from "./dashboards/changefeeds";
 import { getMatchParamByName } from "src/util/query";
+import { PayloadAction } from "src/interfaces/action";
+import {
+  setTimeRange,
+  setTimeScale,
+  TimeWindow,
+  TimeScale,
+} from "src/redux/timewindow";
 
 interface GraphDashboard {
   label: string;
@@ -97,6 +104,8 @@ type MapDispatchToProps = {
   refreshLiveness: typeof refreshLiveness;
   hoverOn: typeof hoverOn;
   hoverOff: typeof hoverOff;
+  setTimeRange: (TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (TimeScale) => PayloadAction<TimeScale>;
 };
 
 type NodeGraphsProps = RouteComponentProps &
@@ -226,7 +235,12 @@ export class NodeGraphs extends React.Component<NodeGraphsProps> {
       const key = `nodes.${dashboard}.${idx}`;
       return (
         <div key={key}>
-          <MetricsDataProvider id={key}>
+          <MetricsDataProvider
+            id={key}
+            setTimeRange={this.props.setTimeRange}
+            setTimeScale={this.props.setTimeScale}
+            history={this.props.history}
+          >
             {React.cloneElement(graph, forwardParams)}
           </MetricsDataProvider>
         </div>
@@ -290,6 +304,8 @@ const mapDispatchToProps: MapDispatchToProps = {
   refreshLiveness,
   hoverOn,
   hoverOff,
+  setTimeRange: setTimeRange,
+  setTimeScale: setTimeScale,
 };
 
 export default compose(

--- a/pkg/ui/src/views/cluster/util/graphs.spec.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.spec.ts
@@ -1,0 +1,32 @@
+import { ComputeByteAxisDomain } from "oss/src/views/cluster/util/graphs";
+import assert from "assert";
+
+describe("ComputeByteAxisDomain", () => {
+  it("should compute an IEC-based domain", () => {
+    const domain = ComputeByteAxisDomain([0, 1000000]);
+    assert.deepEqual(domain.ticks, [256000, 512000, 768000]);
+    assert.equal(domain.tickFormat(256000), "250");
+    assert.equal(domain.guideFormat(256000), "250.00 KiB");
+    assert.equal(domain.label, "KiB");
+  });
+  // This test is here to demonstrate some of the issues that arise
+  // when reusing a tick formatter with different ranges of data than
+  // it was created with
+  it("will produce odd data when extent changes but same tickformat is used", () => {
+    const originalDomain = ComputeByteAxisDomain([0, 1000000]);
+    assert.deepEqual(originalDomain.ticks, [256000, 512000, 768000]);
+    assert.equal(originalDomain.tickFormat(256000), "250");
+    assert.equal(originalDomain.guideFormat(256000), "250.00 KiB");
+    assert.equal(originalDomain.label, "KiB");
+    const newDomain = ComputeByteAxisDomain([0, 1000000000]);
+    assert.deepEqual(newDomain.ticks, [262144000, 524288000, 786432000]);
+    assert.equal(newDomain.tickFormat(262144000), "250");
+    assert.equal(newDomain.guideFormat(262144000), "250.00 MiB");
+    assert.equal(newDomain.label, "MiB");
+    // Now trying new domain with old ticks
+    // The `m` in this case is "milli" meaning `10^-3`
+    // see: https://github.com/d3/d3-format#locale_formatPrefix
+    assert.equal(newDomain.tickFormat(256000), "244.140625m");
+    assert.equal(newDomain.guideFormat(256000), "0.24 MiB");
+  });
+});

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -17,18 +17,19 @@ import moment from "moment";
 import * as protos from "src/js/protos";
 import { NanoToMilli } from "src/util/convert";
 import {
-  DurationFitScale,
   BytesFitScale,
   ComputeByteScale,
   ComputeDurationScale,
+  DurationFitScale,
 } from "src/util/format";
 
 import {
-  MetricProps,
   AxisProps,
   AxisUnits,
+  MetricProps,
   QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
+import uPlot from "uplot";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -70,14 +71,14 @@ const Y_AXIS_TICK_COUNT: number = 3;
 const X_AXIS_TICK_COUNT: number = 10;
 
 // A tuple of numbers for the minimum and maximum values of an axis.
-type Extent = [number, number];
+export type Extent = [number, number];
 
 /**
  * AxisDomain is a class that describes the domain of a graph axis; this
  * includes the minimum/maximum extend, tick values, and formatting information
  * for axis values as displayed in various contexts.
  */
-class AxisDomain {
+export class AxisDomain {
   // the values at the ends of the axis.
   extent: Extent;
   // numbers at which an intermediate tick should be displayed on the axis.
@@ -206,7 +207,7 @@ function ComputeCountAxisDomain(extent: Extent): AxisDomain {
   return axisDomain;
 }
 
-function ComputeByteAxisDomain(extent: Extent): AxisDomain {
+export function ComputeByteAxisDomain(extent: Extent): AxisDomain {
   // Compute an appropriate unit for the maximum value to be displayed.
   const scale = ComputeByteScale(extent[1]);
   const prefixFactor = scale.value;
@@ -257,7 +258,7 @@ const timeIncrementDurations = [
   moment.duration(24, "h"),
   moment.duration(1, "week"),
 ];
-const timeIncrements = _.map(timeIncrementDurations, (inc) =>
+const timeIncrements: number[] = _.map(timeIncrementDurations, (inc) =>
   inc.asMilliseconds(),
 );
 
@@ -292,14 +293,12 @@ function ComputeTimeAxisDomain(extent: Extent): AxisDomain {
   };
 
   axisDomain.guideFormat = (num) => {
-    return moment(num)
-      .utc()
-      .format('HH:mm:ss [<span class="legend-subtext">on</span>] MMM Do, YYYY');
+    return moment(num).utc().format("HH:mm:ss on MMM Do, YYYY");
   };
   return axisDomain;
 }
 
-function calculateYAxisDomain(
+export function calculateYAxisDomain(
   axisUnits: AxisUnits,
   data: TSResponse,
 ): AxisDomain {
@@ -322,7 +321,7 @@ function calculateYAxisDomain(
   }
 }
 
-function calculateXAxisDomain(timeInfo: QueryTimeInfo): AxisDomain {
+export function calculateXAxisDomain(timeInfo: QueryTimeInfo): AxisDomain {
   const xExtent: Extent = [
     NanoToMilli(timeInfo.start.toNumber()),
     NanoToMilli(timeInfo.end.toNumber()),
@@ -330,7 +329,7 @@ function calculateXAxisDomain(timeInfo: QueryTimeInfo): AxisDomain {
   return ComputeTimeAxisDomain(xExtent);
 }
 
-type formattedSeries = {
+export type formattedSeries = {
   values: protos.cockroach.ts.tspb.ITimeSeriesDatapoint[];
   key: string;
   area: boolean;
@@ -526,4 +525,169 @@ function updateLinkedGuideline(
     .attr("x2", (d) => d)
     .attr("y1", () => yExtent[0])
     .attr("y2", () => yExtent[1]);
+}
+
+function calculateYAxisDomainUplot(axisUnits: AxisUnits, yExtent: number[]) {
+  switch (axisUnits) {
+    case AxisUnits.Bytes:
+      return ComputeByteAxisDomain(yExtent);
+    case AxisUnits.Duration:
+      return ComputeDurationAxisDomain(yExtent);
+    case AxisUnits.Percentage:
+      return ComputePercentageAxisDomain(0, 1);
+    default:
+      return ComputeCountAxisDomain(yExtent);
+  }
+}
+
+// configureUPlotLineChart constructs the uplot Options object based on
+// information about the metrics, axis, and data that we'd like to plot.
+// Most of the settings are defined as functions instead of static values
+// in order to take advantage of auto-updating behavior built into uPlot
+// when we send new data to the uPlot object. This will ensure that all
+// axis labeling and extent settings get updated properly.
+export function configureUPlotLineChart(
+  metrics: React.ReactElement<MetricProps>[],
+  axis: React.ReactElement<AxisProps>,
+  data: TSResponse,
+  setTimeRange: (startMillis: number, endMillis: number) => void,
+  getLatestXAxisDomain: () => AxisDomain,
+  getLatestYAxisDomain: () => AxisDomain,
+): uPlot.Options {
+  const formattedRaw = formatMetricData(metrics, data);
+  // Copy palette over since we mutate it in the `series` function
+  // below to cycle through the colors. This ensures that we always
+  // start from the same color for each graph so a single-series
+  // graph will always have the first color, etc.
+  const strokeColors = [...seriesPalette];
+
+  const tooltipPlugin = () => {
+    return {
+      hooks: {
+        init: (self) => {
+          const over = self.root.querySelector(".u-over");
+          const legend = self.root.querySelector(".u-legend");
+
+          // Show/hide legend when we enter/exit the bounds of the graph
+          over.onmouseenter = () => {
+            legend.style.display = "block";
+          };
+
+          over.onmouseleave = () => {
+            legend.style.display = "none";
+          };
+        },
+        setCursor: (self) => {
+          // Place legend to the right of the mouse pointer
+          const legend = self.root.querySelector(".u-legend");
+          if (self.cursor.left > 0 && self.cursor.top > 0) {
+            // TODO(davidh): This placement is not aware of the viewport edges
+            legend.style.left = self.cursor.left + 100 + "px";
+            legend.style.top = self.cursor.top - 10 + "px";
+          }
+        },
+      },
+    };
+  };
+
+  // Please see https://github.com/leeoniya/uPlot/tree/master/docs for
+  // information on how to construct this object.
+  return {
+    width: 947,
+    height: 300,
+    // TODO(davidh): Enable sync-ed guidelines once legend is redesigned
+    // currently, if you enable this with a hovering legend, the FPS
+    // gets quite choppy on large clusters.
+    // cursor: {
+    //   sync: {
+    //     // graphs with matching keys will get their guidelines
+    //     // sync-ed so we just use the same key for the page
+    //     key: "sync-everything",
+    //   },
+    // },
+    legend: {
+      show: true,
+
+      // This setting sets the default legend behavior to isolate
+      // a series when it's clicked in the legend.
+      isolate: true,
+    },
+    // By default, uPlot expects unix seconds in the x axis.
+    // This setting defaults it to milliseconds which our
+    // internal functions already supported.
+    ms: 1,
+    // These settings govern how the individual series are
+    // drawn and how their values are displayed in the legend.
+    series: [
+      {
+        value: (self, rawValue) => getLatestXAxisDomain().guideFormat(rawValue),
+      },
+      // Generate a series object for reach of our results
+      // picking colors from our palette.
+      ...formattedRaw.map((result) => {
+        const color = strokeColors.shift();
+        strokeColors.push(color);
+        return {
+          show: true,
+          scale: "yAxis",
+          width: 1,
+          label: result.key,
+          stroke: color,
+          // Adds transparency to the fill color
+          fill: color + "10",
+          points: {
+            show: false,
+          },
+          // value determines how these values show up in the legend
+          value: (self, rawValue) =>
+            getLatestYAxisDomain().guideFormat(rawValue),
+        };
+      }),
+    ],
+    axes: [
+      {
+        values: (u, vals, space) => vals.map(getLatestXAxisDomain().tickFormat),
+        splits: () => getLatestXAxisDomain().ticks,
+      },
+      {
+        // This label will get overridden in the linegraph's update
+        // callback when we change the y Axis domain.
+        label:
+          axis.props.label +
+          (getLatestYAxisDomain().label
+            ? ` (${getLatestYAxisDomain().label})`
+            : ""),
+        values: (u, vals, space) => vals.map(getLatestYAxisDomain().tickFormat),
+        splits: (u, something, min, max) => {
+          const domain = getLatestYAxisDomain();
+          return [domain.extent[0], ...domain.ticks, domain.extent[1]];
+        },
+        scale: "yAxis",
+      },
+    ],
+    scales: {
+      x: {
+        range: () => getLatestXAxisDomain().extent,
+      },
+      yAxis: {
+        range: () => getLatestYAxisDomain().extent,
+      },
+    },
+    plugins: [tooltipPlugin()],
+    hooks: {
+      // setSelect is a hook that fires when a selection is made on the graph
+      // by dragging a range to zoom.
+      setSelect: [
+        (self) => {
+          // From what I understand, `self.select` contains the pixel edges
+          // of the user's selection. Then I use the `posToIdx` to tell me
+          // what the xAxis range is of the pixels.
+          setTimeRange(
+            self.data[0][self.posToIdx(self.select.left)],
+            self.data[0][self.posToIdx(self.select.left + self.select.width)],
+          );
+        },
+      ],
+    },
+  };
 }

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -568,6 +568,11 @@ export function configureUPlotLineChart(
           const over = self.root.querySelector(".u-over");
           const legend = self.root.querySelector(".u-legend");
 
+          // apply class to stick a legend to the bottom of a chart if it has more than 10 series
+          if (self.series.length > 10) {
+            legend.classList.add("u-legend--place-bottom");
+          }
+
           // Show/hide legend when we enter/exit the bounds of the graph
           over.onmouseenter = () => {
             legend.style.display = "block";

--- a/pkg/ui/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/src/views/shared/components/metricQuery/index.tsx
@@ -35,6 +35,10 @@ import * as protos from "src/js/protos";
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
 import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
+import Long from "long";
+import { History } from "@types/history";
+import { TimeWindow, TimeScale } from "oss/src/redux/timewindow";
+import { PayloadAction } from "oss/src/interfaces/action";
 
 /**
  * AxisUnits is an enumeration used to specify the type of units being displayed
@@ -156,4 +160,7 @@ export interface MetricsDataComponentProps {
   // convenient syntax for a common use case where all metrics on a graph are
   // are from the same source set.
   sources?: string[];
+  setTimeRange: (TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (TimeScale) => PayloadAction<TimeScale>;
+  history: History;
 }

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
@@ -28,6 +28,9 @@ import {
   MetricsDataComponentProps,
   QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
+import { PayloadAction } from "oss/src/interfaces/action";
+import { TimeWindow, TimeScale } from "oss/src/redux/timewindow";
+import { History } from "@types/history";
 
 /**
  * queryFromProps is a helper method which generates a TimeSeries Query data
@@ -87,6 +90,9 @@ interface MetricsDataProviderConnectProps {
   metrics: MetricsQuery;
   timeInfo: QueryTimeInfo;
   requestMetrics: typeof requestMetricsAction;
+  setTimeRange: (TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (TimeScale) => PayloadAction<TimeScale>;
+  history: History;
 }
 
 /**
@@ -215,6 +221,9 @@ class MetricsDataProvider extends React.Component<
     const dataProps: MetricsDataComponentProps = {
       data: this.getData(),
       timeInfo: this.props.timeInfo,
+      setTimeRange: this.props.setTimeRange,
+      setTimeScale: this.props.setTimeScale,
+      history: this.props.history,
     };
     return React.cloneElement(
       child as React.ReactElement<MetricsDataComponentProps>,

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -13610,6 +13610,11 @@ upath@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
+uplot@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.8.tgz#0a7920018de24fa9aa0ba78ab59c99b4a23f8322"
+  integrity sha512-Hqg7iv/3fJlD9nockD7heaUj28RhrIwzugXglnoX//W27wgRAJIJMV2VFMZ5oRVM0RIchByAle1ylf/GdnXgjA==
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"


### PR DESCRIPTION
Currently, most of the charts either display multiple series for every node
in the cluster or some aggregated data with less than 10 series on a chart.
The problem arises when cluster has large amount of nodes, so then legend on
a chart cannot fit all information on a screen.

As a solution, this change handles two possible cases when chart has:
- less than 10 series. It covers cases for aggregated data on a chart
or for clusters with small number of nodes. In this case, the behavior of
legend isn't changed, it sticks to mouse pointer and displays series
as a single column;
- more than 10 series, then legend is displayed right under the chart and
visually looks like it is extended chart's section. Series are placed inline
to fill entire width and minimize growth in height.

https://user-images.githubusercontent.com/3106437/116245396-98b3df00-a771-11eb-9b8a-ce0ab8803ac6.mov

Release note (ui change): stick legend under chart if more than 10 series
provided.